### PR TITLE
Improve Download stats with new Hyperdrive 7.5.0 functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Change types:
   ### Added, ### Changed, ### Fixed, ### Removed, ### Deprecated
 -->
+### Changed
+* Upgrade to hyperdrive 7.5.0
+* Use archive.blocks for stats on download with new hyperdrive functions.
 
 ## 3.4.0 - 2016-09-14
 ### Changed

--- a/index.js
+++ b/index.js
@@ -48,6 +48,8 @@ function Dat (opts) {
     filesProgress: 0,
     bytesTotal: 0,
     bytesProgress: 0,
+    blocksTotal: 0,
+    blocksProgress: 0,
     bytesUp: 0,
     bytesDown: 0
   }
@@ -198,28 +200,35 @@ Dat.prototype.download = function (cb) {
     if (err) return cb(err)
     self.live = archive.live
     self.db.put('!dat!key', archive.key.toString('hex'))
+    updateTotalStats() //  Call once for downloads already finished
 
-    archive.metadata.once('download-finished', updateTotalStats)
+    archive.metadata.once('download-finished', updateTotalStats) // Updates total on live sync
 
     archive.content.on('download-finished', function () {
-      if (self.stats.bytesTotal === 0) updateTotalStats() // TODO: why is this getting here with 0
       self.emit('download-finished')
     })
 
-    each(archive.list({live: archive.live}), function (data, next) {
-      var startBytes = self.stats.bytesProgress
-      archive.download(data, function (err) {
+    each(archive.list({live: archive.live}), function (entry, next) {
+      if (archive.isEntryDownloaded(entry)) {
+        self.stats.blocksProgress += entry.blocks
+        return entryDone()
+      }
+      var downloaded = archive.countDownloadedBlocks(entry)
+      self.stats.blocksProgress += downloaded
+      archive.download(entry, function (err) {
         if (err) return cb(err)
-        if (startBytes === self.stats.bytesProgress) {
-          // TODO: better way to measure progress with existing files
-          self.stats.bytesProgress += data.length
-        }
-        if (data.type === 'file') {
+        // self.stats.bytesProgress += entry.length - bytesDown
+        entryDone()
+      })
+
+      function entryDone () {
+        if (entry.type === 'file') {
           self.stats.filesProgress++
-          self.emit('file-downloaded', data)
+          self.stats.bytesProgress += entry.length
+          self.emit('file-downloaded', entry)
         }
         next()
-      })
+      }
     }, function (err) {
       if (err) return cb(err)
       return cb(null)
@@ -231,13 +240,8 @@ Dat.prototype.download = function (cb) {
     self.emit('archive-updated')
   })
 
-  archive.once('download', function () {
-    // TODO: fix https://github.com/maxogden/dat/issues/502
-    if (self.stats.bytesTotal === 0) updateTotalStats()
-  })
-
   archive.on('download', function (data) {
-    self.stats.bytesProgress += data.length
+    self.stats.blocksProgress++
     self.stats.bytesDown += data.length
     self.emit('download', data)
   })
@@ -249,6 +253,7 @@ Dat.prototype.download = function (cb) {
 
   function updateTotalStats () {
     self.stats.bytesTotal = archive.content ? archive.content.bytes : 0
+    self.stats.blocksTotal = archive.content ? archive.content.blocks : 0
     var fileCount = 0
     each(archive.list({live: false}), function (data, next) {
       if (data.type === 'file') fileCount++

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "anymatch": "^1.3.0",
     "dat-encoding": "^2.0.2",
     "folder-walker": "^3.0.0",
-    "hyperdrive": "^7.4.0",
+    "hyperdrive": "^7.5.0",
     "hyperdrive-archive-swarm": "^4.1.4",
     "hyperdrive-import-files": "^2.2.1",
     "level": "^1.4.0",

--- a/readme.md
+++ b/readme.md
@@ -163,12 +163,14 @@ Stats we track internally for progress displays. It is not recommended to use th
 
 ```js
 dat.stats = {
-    filesProgress: 0,
-    bytesProgress: 0,
     filesTotal: 0,
-    bytesTotal: 0,
-    bytesUp: 0,
-    bytesDown: 0
+    filesProgress: 0,
+    bytesTotal: 0, // archive.content.bytes
+    bytesProgress: 0, // file import progress
+    blocksTotal: 0, // archive.content.blocks
+    blocksProgress: 0, // download progress
+    bytesUp: 0, // archive.on('upload', data.length)
+    bytesDown: 0 // archive.on('download', data.length)
 }
 ```
 

--- a/tests/download.js
+++ b/tests/download.js
@@ -52,6 +52,9 @@ test('Download with default opts', function (t) {
   dat.once('download-finished', function () {
     t.same(dat.stats.filesTotal, stats.filesTotal, 'files total match')
     t.same(dat.stats.bytesTotal, stats.bytesTotal, 'bytes total match')
+    // These are wrong b/c download-finished fires before the last download events
+    t.skip(dat.stats.filesTotal, dat.stats.filesProgress, 'TODO: file total matches progress')
+    t.skip(dat.stats.blocksTotal, dat.stats.blockProgress, 'TODO: block total matches progress')
     t.pass('download finished event')
 
     fs.readdir(downloadDir, function (_, files) {


### PR DESCRIPTION
Hyperdrive 7.5.0 added two new functions to make it easier to see existing download progress: [`archive.countDownloadedBlocks(entry)`](https://github.com/mafintosh/hyperdrive#archivecountdownloadedblocksentry) and [`archive.isEntryDownloaded(entry)`](https://github.com/mafintosh/hyperdrive#archiveisentrydownloadedentry). 

This PR uses blocks to track download progress, including checking for already downloaded progress. Progress is now more accurate for resumed downloads. Addresses #11 & #10.

Unfortunately, we cannot use blocks on the sharing side (we don't know number of blocks until they happen). So progress is now measured differently for share & download (bytes and blocks, respectively). 

This is not backwards compatible. 