### PR TITLE
fix(share): download instead of warn

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,8 +100,7 @@ Dat.prototype.share = function (cb) {
     if (err) return cb(err)
 
     if (archive.key && !archive.owner) {
-      // TODO: allow this but change to download
-      return cb('Dat previously downloaded. Run dat ' + encoding.encode(archive.key) + ' to resume')
+      return self.download()
     }
 
     if ((archive.live || archive.owner) && archive.key) {

--- a/tests/share.js
+++ b/tests/share.js
@@ -151,7 +151,9 @@ if (!process.env.TRAVIS) {
         t.same(dat.stats.filesTotal, stats.filesTotal + 1, 'files total correct')
         fs.unlink(newFile, function () {
           dat.close(function () {
-            t.end()
+            dat.db.close(function () {
+              t.end()
+            })
           })
         })
       })
@@ -166,6 +168,50 @@ if (!process.env.TRAVIS) {
     })
   })
 }
+
+test('dat should resume if dir is already a dat', function (t) {
+  t.plan(6)
+
+  dat = Dat({dir: fixtures})
+
+  setup(function (err) {
+    t.error(err, 'no errors on setup')
+
+    dat = Dat({dir: fixtures})
+    dat.open(function () {
+      fs.stat(path.join(fixtures, '.dat'), function (err, stat) {
+        t.error(err, 'no errors opening')
+      })
+
+      dat.share(function (err) {
+        t.error(err, 'no errors sharing')
+        dat.close(function () {
+          dat.db.close(function () {
+            cleanFixtures(function () {
+              t.pass('all done!')
+            })
+          })
+        })
+      })
+    })
+  })
+
+  // setup dat once, then close and call cb
+  function setup (cb) {
+    dat.open(function () {
+      fs.stat(path.join(fixtures, '.dat'), function (err, stat) {
+        t.error(err, 'no errors opening')
+      })
+
+      dat.share(function (err) {
+        t.error(err, 'no errors sharing')
+        dat.close(function () {
+          dat.db.close(cb)
+        })
+      })
+    })
+  }
+})
 
 test('cleanup', function (t) {
   dat.close(cleanFixtures(function () {


### PR DESCRIPTION
Start seeding a file rather than warning the user they should seed the
file. Thanks! :sparkles:
- closes: https://github.com/joehand/dat-js/issues/15